### PR TITLE
fix: add @standard-schema/spec as dependency to properly reflect types

### DIFF
--- a/examples/global/app.controller.ts
+++ b/examples/global/app.controller.ts
@@ -1,0 +1,17 @@
+import { Body, Controller, Post } from "@nestjs/common";
+import { z } from "zod";
+import { createStandardSchemaDTO } from "../../dist";
+
+class HelloDTO extends createStandardSchemaDTO(
+  z.object({
+    name: z.string(),
+  }),
+) {}
+
+@Controller()
+export class AppController {
+  @Post("hello")
+  sayHello(@Body() body: HelloDTO) {
+    return `Hello ${body.name}`;
+  }
+}

--- a/examples/global/app.module.ts
+++ b/examples/global/app.module.ts
@@ -1,0 +1,4 @@
+import { Module } from "@nestjs/common";
+
+@Module({})
+export class AppModule {}

--- a/examples/global/main.ts
+++ b/examples/global/main.ts
@@ -1,0 +1,12 @@
+import { NestFactory } from "@nestjs/core";
+import { StandardSchemaValidationPipe } from "../../dist";
+import { AppModule } from "./app.module";
+
+async function main() {
+  const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new StandardSchemaValidationPipe());
+
+  await app.listen(3000);
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "name": "nestjs-standard-schema",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lancelotp/nestjs-standard-schema"
+  },
   "version": "0.1.0",
   "description": "NestJS DTO validation based on standard schema",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -26,12 +26,15 @@
   ],
   "author": "Lancelot Prigent <lancelot@prigent.dev> (https://github.com/lancelotp)",
   "license": "MIT",
+  "dependencies": { 
+    "@standard-schema/spec": "^1.0.0"
+  },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@nestjs/common": "^11.0.7",
+    "@nestjs/core": "^11.0.7",
     "@nestjs/platform-express": "^11.0.7",
     "@nestjs/testing": "^11.0.7",
-    "@standard-schema/spec": "^1.0.0",
     "@types/jest": "^29.5.14",
     "@types/supertest": "^6.0.2",
     "class-transformer": "^0.5.1",
@@ -44,7 +47,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@nestjs/common": "^11.0.7"
+    "@nestjs/common": "^10.0.0 || ^11.0.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@standard-schema/spec':
+        specifier: ^1.0.0
+        version: 1.0.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
@@ -14,15 +18,15 @@ importers:
       '@nestjs/common':
         specifier: ^11.0.7
         version: 11.0.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/core':
+        specifier: ^11.0.7
+        version: 11.0.7(@nestjs/common@11.0.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@11.0.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/platform-express':
         specifier: ^11.0.7
         version: 11.0.7(@nestjs/common@11.0.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@11.0.7)
       '@nestjs/testing':
         specifier: ^11.0.7
         version: 11.0.7(@nestjs/common@11.0.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@11.0.7)(@nestjs/platform-express@11.0.7)
-      '@standard-schema/spec':
-        specifier: ^1.0.0
-        version: 1.0.0
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14


### PR DESCRIPTION
Previously the lib @standard-schema/spec was a devDep causing importers to not have the properly typed DTOs